### PR TITLE
Force searching the custom boost version

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-control-toolbox
 	pkgdesc = ROS - The control toolbox contains modules that are useful across all controllers.
 	pkgver = 1.18.2
-	pkgrel = 2
+	pkgrel = 3
 	url = https://wiki.ros.org/control_toolbox
 	arch = i686
 	arch = x86_64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgname='ros-melodic-control-toolbox'
 pkgver='1.18.2'
 _pkgver_patch=0
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=2
+pkgrel=3
 license=('BSD')
 
 ros_makedepends=(ros-melodic-dynamic-reconfigure
@@ -64,7 +64,8 @@ build() {
         -DCMAKE_INSTALL_PREFIX=/opt/ros/melodic \
         -DPYTHON_EXECUTABLE=/usr/bin/python3 \
         -DSETUPTOOLS_DEB_LAYOUT=OFF \
-        -DBOOST_ROOT=/opt/boost1.69
+        -DBOOST_ROOT=/opt/boost1.69 \
+        -DBoost_NO_SYSTEM_PATHS=TRUE
   make
 }
 


### PR DESCRIPTION
Otherwise, if a system boost version is present, that one will be used.

This could be a way to get around the issue that packages will be built against the system boost version, if installed which would be the case for probably anybody trying to build any package in a non-chroot env.

@bionade24 Do you think this would be a valid way to mitigate this? Then we could add this to all packages.